### PR TITLE
tests: use Vitest's `test.each` for passing in multiple test cases

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
 export { getDifference, getIntersection, getSymmetricDifference, getUnion } from './operations';
-export { areSetsDisjoint, areSetsEqual, areSetsEquivalent, isProperSubsetOf, isProperSupersetOf, isSubsetOf, isSupersetOf } from './predicates';
+export { areSetsDisjoint, areSetsEqual, areSetsEquivalent, containsAllElements, isProperSubsetOf, isProperSupersetOf, isSubsetOf, isSupersetOf } from './predicates';
 export { getJaccardSimilarityCoefficient, getLogDice, getOverlapCoefficient, getSorensenDiceCoefficient } from './similarity';
 export type { SetFunction, SetOperation, SetPredicate, SetSimilarity } from './types';

--- a/src/predicates.ts
+++ b/src/predicates.ts
@@ -170,7 +170,7 @@ export function isSupersetOf<TElement>(a: Set<TElement>, b: Set<TElement>): bool
  * @param b - Set B of type `<TElement>` elements
  * @returns Whether A contains all elements of B
  */
-function containsAllElements<TElement>(a: Set<TElement>, b: Set<TElement>): boolean {
+export function containsAllElements<TElement>(a: Set<TElement>, b: Set<TElement>): boolean {
 	for (const element of b) {
 		if (!a.has(element)) {
 			return false;

--- a/tests/operations.spec.ts
+++ b/tests/operations.spec.ts
@@ -1,72 +1,67 @@
 import { describe, expect, test } from 'vitest';
 
-import { getDifference, getIntersection, getSymmetricDifference, getUnion } from '../src';
+import {
+	getDifference,
+	getIntersection,
+	getSymmetricDifference,
+	getUnion,
+} from '../src';
 
 describe('getDifference', () => {
-	test('difference of sets is computed correctly [1]', () => {
+	test.each([
+		[[], [], []],
+		[[1, 2, 3], [2, 3, 4], [1]],
+		[[1, 2, 3, 4, 5, 6, 7, 8], [1, 2, 3, 4], [5, 6, 7, 8]],
+	])('%O \\ %O = %O', (a, b, expected) => {
 		expect(getDifference(
-			new Set([1, 2, 3, 4, 5, 6, 7, 8]),
-			new Set([1, 2, 3, 4]),
-		)).toStrictEqual(new Set([5, 6, 7, 8]));
-	});
-    
-    
-	test('difference of two sets is computed correctly [2]', () => {
-		expect(getDifference(
-			new Set<number>([1, 2, 3]),
-			new Set<number>([2, 3, 4]),
-		)).toStrictEqual(
-			new Set<number>([1]),
-		);
+			new Set(a),
+			new Set(b),
+		)).toStrictEqual(new Set(expected));
 	});
 });
 
 describe('getIntersection', () => {
-	test('intersection of two sets is computed correctly [1]', () => {
+	test.each([
+		[[1, 2, 3], [4, 5, 6], []],
+		[[1, 2, 3], [2, 3, 4], [2, 3]],
+		[[8, 9, 10, 11, 12, 13, 14, 15], [14, 15, 16, 17, 18, 19, 20], [14, 15]],
+	])('%O ∩ %O = %O', (a, b, expected) => {
 		expect(getIntersection<number>(
-			new Set<number>([1, 2, 3]),
-			new Set<number>([2, 3, 4]),
+			new Set<number>(a),
+			new Set<number>(b),
 		)).toStrictEqual(
-			new Set<number>([2, 3]),
-		);
-	});
-    
-	test('intersection of two sets is computed correctly [2]', () => {
-		expect(getIntersection(
-			new Set([8, 9, 10, 11, 12, 13, 14, 15]),
-			new Set([14, 15, 16, 17, 18, 19, 20]),
-		)).toStrictEqual(new Set([14, 15]));
-	});
-    
-    
-	test('intersection of two sets without any common elements returns an empty set', () => {
-		expect(getIntersection<number>(
-			new Set<number>([1, 2, 3]),
-			new Set<number>([4, 5, 6]),
-		)).toStrictEqual(
-			new Set<number>([]),
+			new Set<number>(expected),
 		);
 	});
 });
 
 describe('getSymmetricDifference', () => {
-	test('symmetric difference of two sets is computed correctly', () => {
+	test.each([
+		[[], [], []],
+		[[1, 2, 3], [1, 2, 3], []],
+		[[1, 2, 3], [3, 4], [1, 2, 4]],
+		[[1, 2, 3], [4, 5, 6], [1, 2, 3, 4, 5, 6]],
+	])('%O △ %O = %O', (a, b, expected) => {
 		expect(getSymmetricDifference(
-			new Set<number>([1, 2, 3]),
-			new Set<number>([3, 4]),
+			new Set<number>(a),
+			new Set<number>(b),
 		)).toStrictEqual(
-			new Set<number>([1, 2, 4]),
+			new Set<number>(expected),
 		);
 	});
 });
 
 describe('getUnion', () => {
-	test('union of two sets is computed correctly', () => {
+	test.each([
+		[[], [], []],
+		[[1, 2, 3], [2, 3, 4], [1, 2, 3, 4]],
+		[[1, 2, 3, 4], [5, 6, 7, 8], [1, 2, 3, 4, 5, 6, 7, 8]],
+	])('%O ∪ %O = %O', (a, b, expected) => {
 		expect(getUnion<number>(
-			new Set<number>([1, 2, 3, 4]),
-			new Set<number>([5, 6, 7, 8]),
+			new Set<number>(a),
+			new Set<number>(b),
 		)).toStrictEqual(
-			new Set<number>([1, 2, 3, 4, 5, 6, 7, 8]),
+			new Set<number>(expected),
 		);
 	});
 });

--- a/tests/predicates.spec.ts
+++ b/tests/predicates.spec.ts
@@ -1,87 +1,103 @@
 import { describe, expect, test } from 'vitest';
 
-import { areSetsDisjoint, areSetsEqual, areSetsEquivalent, isProperSubsetOf, isProperSupersetOf, isSubsetOf, isSupersetOf } from '../src';
+import {
+	areSetsDisjoint,
+	areSetsEqual,
+	areSetsEquivalent,
+	isProperSubsetOf,
+	isProperSupersetOf,
+	isSubsetOf,
+	isSupersetOf,
+} from '../src';
 
 describe('areSetsDisjoint', () => {
-	test('two sets are disjoint to each other', () => {
+	test.each([
+		[true, [], []],
+		[true, [1, 2, 3], [4, 5, 6]],
+		[false, [1, 2, 3], [3, 4, 5]],
+	])('A ∩ B = ϕ is %O, (A = %O, B = %O)', (expected, a, b) => {
 		expect(areSetsDisjoint(
-			new Set<number>([1, 2, 3]),
-			new Set<number>([4, 5, 6]),
-		)).toBe(true);
-	});
-
-	test('two sets are not disjoint to each other', () => {
-		expect(areSetsDisjoint(
-			new Set<number>([1, 2, 3]),
-			new Set<number>([3, 4, 5]),
-		)).toBe(false);
+			new Set<number>(a),
+			new Set<number>(b),
+		)).toBe(expected);
 	});
 });
 
 describe('areSetsEqual', () => {
-	test('two sets are equal to each other', () => {
+	test.each([
+		[true, [], []],
+		[true, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5]],
+	])('A = B is %O, (A = %O, B = %O)', (expected, a, b) => {
 		expect(areSetsEqual(
-			new Set([1, 2, 3, 4, 5]),
-			new Set([1, 2, 3, 4, 5]),
-		)).toBe(true);
-	});
-    
-	test('two empty sets are equal to each other', () => {
-		expect(areSetsEqual<number>(
-			new Set<number>([]),
-			new Set<number>([]),
-		)).toBe(true);
+			new Set(a),
+			new Set(b),
+		)).toBe(expected);
 	});
 });
 
 describe('areSetsEquivalent', () => {
-	test('two empty sets are equivalent to each other', () => {
+	test.each([
+		[true, [], []],
+		[true, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [11, 12, 13, 14, 15, 16, 17, 18, 19, 20]],
+		[false, [1, 2, 3], []],
+	])('|A| = |B| is %O, (A = %O, B = %O)', (expected, a, b) => {
 		expect(areSetsEquivalent<number>(
-			new Set<number>(),
-			new Set<number>(),
-		)).toBe(true);
-	});
-
-	test('two sets of same length are equivalent to each other', () => {
-		expect(areSetsEquivalent<number>(
-			new Set<number>([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
-			new Set<number>([11, 12, 13, 14, 15, 16, 17, 18, 19, 20]),
-		)).toBe(true);
+			new Set<number>(a),
+			new Set<number>(b),
+		)).toBe(expected);
 	});
 });
 
 describe('isProperSubsetOf', () => {
-	test('set A is correctly computed as a proper subset of set B', () => {
+	test.each([
+		[true, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 6, 7, 8, 9]],
+		[false, [1, 2, 3], [1, 2, 3]],
+		[false, [], []],
+	])('A ⊂ B is %O, (A = %O, B = %O)', () => {
 		expect(isProperSubsetOf(
 			new Set([1, 2, 3, 4, 5]),
 			new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]),
 		)).toBe(true);
-	});    
+	});
 });
 
 describe('isProperSupersetOf', () => {
-	test('set A is correctly defined as a proper superset of set B', () => {
+	test.each([
+		[true, [1, 2, 3, 4, 5, 6, 7, 8, 9], [1, 2, 3, 4, 5]],
+		[false, [1, 2, 3], [1, 2, 3]],
+		[false, [], []],
+	])('A ⊃ B is %O, (A = %O, B = %O)', (expected, a, b) => {
 		expect(isProperSupersetOf(
-			new Set([1, 2, 3, 4, 5, 6, 7, 8, 9]),
-			new Set([1, 2, 3, 4, 5]),
-		)).toBe(true);
-	});    
+			new Set(a),
+			new Set(b),
+		)).toBe(expected);
+	});
 });
 
 describe('isSubsetOf', () => {
-	test('set A is correctly defined as a subset of B', () => {
+	test.each([
+		[true, [1, 2, 3, 4, 5], [1, 2, 3, 4, 5, 9]],
+		[false, [1, 2, 3, 4, 5, 9], [1, 2, 3, 4, 5]],
+		[true, [1, 2, 3], [1, 2, 3]],
+		[true, [], []],
+	])('A ⊆ B is %O, (A = %O, B = %O)', (expected, a, b) => {
 		expect(isSubsetOf(
-			new Set([1, 2, 3, 4, 5]),
-			new Set([1, 2, 3, 4, 5, 9]),
-		)).toBe(true);
-	});    
+			new Set(a),
+			new Set(b),
+		)).toBe(expected);
+	});
 });
 
 describe('isSupersetOf', () => {
-	test('set A is a superset of set B', () => {
+	test.each([
+		[true, [1, 2, 3, 4, 5, 7], [1, 3, 7]],
+		[false, [1, 3, 7], [1, 2, 3, 4, 5, 7]],
+		[true, [1, 3, 7], [1, 3, 7]],
+		[true, [], []],
+	])('A ⊇ B is %O, (A = %O, B = %O) ', (expected, a, b) => {
 		expect(isSupersetOf(
-			new Set([1, 2, 3, 4, 5, 7]),
-			new Set([1, 3, 7]),
-		)).toBe(true);
-	});    
+			new Set(a),
+			new Set(b),
+		)).toBe(expected);
+	});
 });

--- a/tests/predicates.spec.ts
+++ b/tests/predicates.spec.ts
@@ -4,11 +4,25 @@ import {
 	areSetsDisjoint,
 	areSetsEqual,
 	areSetsEquivalent,
+	containsAllElements,
 	isProperSubsetOf,
 	isProperSupersetOf,
 	isSubsetOf,
 	isSupersetOf,
 } from '../src';
+
+describe('containsAllElements', () => {
+	test.each([
+		[[1, 2, 3], [1, 2], true],
+		[[1, 2, 3], [], true],
+		[[1, 2, 3], [4], false],
+	])('%O contains %O is %O', (a, b, expected) => {
+		expect(containsAllElements(
+			new Set(a),
+			new Set(b),
+		)).toBe(expected);
+	});
+});
 
 describe('areSetsDisjoint', () => {
 	test.each([

--- a/tests/similarity.spec.ts
+++ b/tests/similarity.spec.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest';
 
-import { getJaccardSimilarityCoefficient, getLogDice, getOverlapCoefficient, getSorensenDiceCoefficient } from '../src';
+import {
+	getJaccardSimilarityCoefficient,
+	getLogDice,
+	getOverlapCoefficient,
+	getSorensenDiceCoefficient,
+} from '../src';
 
 describe('Jaccard\'s Similarity Coefficient', () => {
 

--- a/tests/similarity.spec.ts
+++ b/tests/similarity.spec.ts
@@ -3,26 +3,26 @@ import { describe, expect, test } from 'vitest';
 import { getJaccardSimilarityCoefficient, getLogDice, getOverlapCoefficient, getSorensenDiceCoefficient } from '../src';
 
 describe('Jaccard\'s Similarity Coefficient', () => {
-	test('comparing "hello world" and "world hello" will result in 100% score', () => {
-		expect(getJaccardSimilarityCoefficient(
-			new Set('hello world'.split(' ')),
-			new Set('world hello'.split(' ')),
-		)).toBeCloseTo(1.0);
-	});
 
-	test('two equal sets are equally similar', () => {
+	test.each([
+		['hello world', 'world hello', 1.0],
+		['', '', 1.0],
+	])('comparing "%s" and "%s" will give a score of %f', (a, b, expected) => {
 		expect(getJaccardSimilarityCoefficient(
-			new Set([]),
-			new Set([]),
-		)).toBeCloseTo(1.0);
+			new Set(a.split(' ')),
+			new Set(b.split(' ')),
+		)).toBeCloseTo(expected);
 	});
 });
 
 describe('Pavel Rychlý\'s LogDice', () => {
-	test('getLogDice returns 14 for full similarity', () => {
+	test.each([
+		['hello world', 'world hello'],
+		['', ''],
+	])('comparing "%s" and "%s" will give 14 for full similarity', (a, b) => {
 		expect(getLogDice(
-			new Set('hello world'.split('')),
-			new Set('world hello'.split('')),
+			new Set(a.split(' ')),
+			new Set(b.split(' ')),
 		)).toBe(14);
 	});
 });

--- a/tests/similarity.spec.ts
+++ b/tests/similarity.spec.ts
@@ -8,22 +8,21 @@ import {
 } from '../src';
 
 describe('Jaccard\'s Similarity Coefficient', () => {
-
 	test.each([
-		['hello world', 'world hello', 1.0],
-		['', '', 1.0],
+		[[], [], 1],
+		[['hello', 'world'], ['world', 'hello'], 1],
 	])('comparing "%s" and "%s" will give a score of %f', (a, b, expected) => {
 		expect(getJaccardSimilarityCoefficient(
-			new Set(a.split(' ')),
-			new Set(b.split(' ')),
+			new Set(a),
+			new Set(b),
 		)).toBeCloseTo(expected);
 	});
 });
 
 describe('Pavel Rychlý\'s LogDice', () => {
 	test.each([
-		['hello world', 'world hello'],
 		['', ''],
+		['hello world', 'world hello'],
 	])('comparing "%s" and "%s" will give 14 for full similarity', (a, b) => {
 		expect(getLogDice(
 			new Set(a.split(' ')),


### PR DESCRIPTION
- Removes some extra trailing whitespace in various test files
- Reverts #240, re-exports `containsAllElements()`